### PR TITLE
Change grep command to also work on a mac

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -6,5 +6,5 @@ if sort --help | grep -q -- '-V'; then
 fi
 
 uri="http://smlnj.cs.uchicago.edu/dist/working/"
-ver=$(curl -s $uri | grep -Po "(?<=<b>)[0-9.]+(?=</b>)" | uniq | $sort_cmd)
+ver=$(curl -s $uri | grep -Eo "[0-9]+\.[0-9]+" | uniq | $sort_cmd)
 echo $ver


### PR DESCRIPTION
This pull request changes the `grep` command so it can also work on a mac.
Mac's grep command does not implement `-P` flag, which caused the error reported on #1 .

Closes #1 